### PR TITLE
MARKET_IF_TOUCHED_CREATE is now MARKET_IF_TOUCHED_ORDER_CREATE

### DIFF
--- a/events.go
+++ b/events.go
@@ -404,7 +404,7 @@ func asEvent(header *evtHeaderContent, body *evtBody) (Event, error) {
 		return &AccountCreateEvent{evtHeader{header}, body}, nil
 	case "MARKET_ORDER_CREATE":
 		return &TradeCreateEvent{evtHeader{header}, body}, nil
-	case "LIMIT_ORDER_CREATE", "STOP_ORDER_CREATE", "MARKET_IF_TOUCHED_CREATE":
+	case "LIMIT_ORDER_CREATE", "STOP_ORDER_CREATE", "MARKET_IF_TOUCHED_ORDER_CREATE":
 		return &OrderCreateEvent{evtHeader{header}, body}, nil
 	case "ORDER_UPDATE":
 		return &OrderUpdateEvent{evtHeader{header}, body}, nil


### PR DESCRIPTION
Oanda apparently doesn't honor backwards compatibility guarantees in order type naming.